### PR TITLE
CSC-2352: Update ObjectPlace Hierachy table/view/functions for numberofobjects/objectcount schema change.

### DIFF
--- a/pahma/hierarchies/object_location/CreateObjectPlaceLocationTable.sql
+++ b/pahma/hierarchies/object_location/CreateObjectPlaceLocationTable.sql
@@ -7,20 +7,18 @@ $$
 DROP TABLE IF EXISTS utils.object_place_location CASCADE;
 CREATE TABLE utils.object_place_location AS
   SELECT
-      o.id,
-      l.collectionobjectcsid,
-      o.objectnumber,
-      o.numberofobjects,
-      o.placecsid,
-      p.placename,
-      p.csid_hierarchy AS place_csid_hierarchy,
-      l.storagelocation,
-      l.crate
-    FROM utils.object_place_temp o
-      LEFT OUTER JOIN  utils.placename_hierarchy p
-        ON (o.placecsid = p.placecsid)
-      LEFT OUTER JOIN  utils.current_location_temp l
-        ON (o.id = l.collectionobjectcsid);
+    o.id,
+    l.collectionobjectcsid,
+    o.objectnumber,
+    o.numberofobjects,
+    o.placecsid,
+    p.placename,
+    p.csid_hierarchy AS place_csid_hierarchy,
+    l.storagelocation,
+    l.crate
+  FROM utils.object_place_temp o
+  LEFT OUTER JOIN  utils.placename_hierarchy p ON (o.placecsid = p.placecsid)
+  LEFT OUTER JOIN  utils.current_location_temp l ON (o.id = l.collectionobjectcsid);
 
   CREATE INDEX opn_id_ndx
   ON utils.object_place_location (id);

--- a/pahma/hierarchies/object_location/CreateObjectPlaceTable.sql
+++ b/pahma/hierarchies/object_location/CreateObjectPlaceTable.sql
@@ -4,16 +4,26 @@
 CREATE or REPLACE FUNCTION utils.createObjectPlaceTable() RETURNS VOID AS
 $$
   DROP TABLE IF EXISTS utils.object_place_temp;
-  SELECT DISTINCT *  INTO utils.object_place_temp FROM (
-        SELECT c.id, h1.name collectionobjectcsid, c.numberofobjects numberofobjects, c.objectnumber objectnumber, pn.placecsid placecsid
-        FROM collectionobjects_common c
-        JOIN misc m ON (m.id=c.id AND m.lifecyclestate<>'deleted')
-        JOIN hierarchy h1 ON (c.id=h1.id)
-        LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl ON (pl.pos=0 AND c.id=pl.id)
-        LEFT OUTER JOIN places_common pc ON (pc.refname = pl.item)
-        LEFT OUTER JOIN hierarchy h2 ON (h2.id=pc.id)
-        LEFT OUTER JOIN utils.placename_hierarchy pn ON (h2.primarytype='PlaceitemTenant15' AND pn.placecsid=h2.name)
-  ) AS object_place_subquery;
+
+  SELECT DISTINCT *  INTO utils.object_place_temp
+  FROM (
+    SELECT
+      cc.id,
+      hc.name collectionobjectcsid,
+      ocg.objectcount objectcount,
+      cc.objectnumber numberofobjects,
+      pn.placecsid placecsid
+    FROM collectionobjects_common cc
+    JOIN misc m ON (cc.id = m.id AND m.lifecyclestate <> 'deleted')
+    JOIN hierarchy hcc ON (cc.id = hcc.id)
+    LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.id AND hocg.primarytype = 'objectCountGroup' AND hocg.pos = 0)
+    LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+    LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl ON (cc.id = pl.id AND pl.pos = 0)
+    LEFT OUTER JOIN places_common pc ON (pl.item = pc.refname)
+    LEFT OUTER JOIN hierarchy hpc ON (pc.id = hpc.id AND hpc.primarytype = 'PlaceitemTenant15')
+    LEFT OUTER JOIN utils.placename_hierarchy pn ON (hpc.name = pn.placecsid)
+    ) AS object_place_subquery;
+
   CREATE INDEX opt_placecsid_ndx ON utils.object_place_temp(placecsid);
 $$
 LANGUAGE SQL

--- a/pahma/hierarchies/object_location/CreateObjectPlaceTable.sql
+++ b/pahma/hierarchies/object_location/CreateObjectPlaceTable.sql
@@ -9,14 +9,14 @@ $$
   FROM (
     SELECT
       cc.id,
-      hc.name collectionobjectcsid,
+      hcc.name collectionobjectcsid,
       ocg.objectcount objectcount,
       cc.objectnumber numberofobjects,
       pn.placecsid placecsid
     FROM collectionobjects_common cc
     JOIN misc m ON (cc.id = m.id AND m.lifecyclestate <> 'deleted')
     JOIN hierarchy hcc ON (cc.id = hcc.id)
-    LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.id AND hocg.primarytype = 'objectCountGroup' AND hocg.pos = 0)
+    LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid AND hocg.primarytype = 'objectCountGroup' AND hocg.pos = 0)
     LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
     LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl ON (cc.id = pl.id AND pl.pos = 0)
     LEFT OUTER JOIN places_common pc ON (pl.item = pc.refname)

--- a/pahma/hierarchies/object_location/CreateObjectPlaceView.sql
+++ b/pahma/hierarchies/object_location/CreateObjectPlaceView.sql
@@ -6,21 +6,19 @@ CREATE or REPLACE FUNCTION utils.createObjectPlaceView() RETURNS VOID AS
 $$
   CREATE OR REPLACE VIEW utils.object_place_view AS
   SELECT
-      c.id,
-      h1.name collectionobjectcsid,
-      c.numberofobjects numberofobjects,
-      c.objectnumber objectnumber,
-      pn.placecsid placecsid
-    FROM
-      collectionobjects_common c
-      JOIN misc m ON( m.id = c.id and m.lifecyclestate <> 'deleted' )
-      JOIN hierarchy h1 ON( c.id = h1.id )
-      JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl
-        ON( pl.pos = 0 AND c.id = pl.id )
-      JOIN places_common pc ON( pc.refname = pl.item )
-      JOIN hierarchy h2 ON( h2.id = pc.id )
-      JOIN utils.placename_hierarchy pn
-        ON( h2.primarytype = 'PlaceitemTenant15'
-            AND pn.placecsid = h2.name )
+    cc.id,
+    hcc.name collectionobjectcsid,
+    cc.objectcount numberofobjects,
+    cc.objectnumber objectnumber,
+    pn.placecsid placecsid
+  FROM collectionobjects_common cc
+  JOIN misc m ON (c.id = m.id AND m.lifecyclestate <> 'deleted')
+  JOIN hierarchy hcc ON (cc.id = hcc.id)
+  LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.id AND hocg.primarytype = 'objectCountGroup' AND hocg.pos = 0)
+  LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+  JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl ON (c.id = pl.id AND pl.pos = 0)
+  JOIN places_common pc ON (pl.item = pc.refname)
+  JOIN hierarchy hpc ON (pc.id = hpc.id AND hpc.primarytype = 'PlaceitemTenant15')
+  JOIN utils.placename_hierarchy pn ON (hpc.name = pn.placecsid)
 $$
 LANGUAGE SQL

--- a/pahma/hierarchies/object_location/CreateObjectPlaceView.sql
+++ b/pahma/hierarchies/object_location/CreateObjectPlaceView.sql
@@ -8,15 +8,15 @@ $$
   SELECT
     cc.id,
     hcc.name collectionobjectcsid,
-    cc.objectcount numberofobjects,
+    ocg.objectcount numberofobjects,
     cc.objectnumber objectnumber,
     pn.placecsid placecsid
   FROM collectionobjects_common cc
-  JOIN misc m ON (c.id = m.id AND m.lifecyclestate <> 'deleted')
+  JOIN misc m ON (cc.id = m.id AND m.lifecyclestate <> 'deleted')
   JOIN hierarchy hcc ON (cc.id = hcc.id)
-  LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.id AND hocg.primarytype = 'objectCountGroup' AND hocg.pos = 0)
+  LEFT OUTER JOIN hierarchy hocg ON (hcc.id = hocg.parentid AND hocg.primarytype = 'objectCountGroup' AND hocg.pos = 0)
   LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
-  JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl ON (c.id = pl.id AND pl.pos = 0)
+  JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pl ON (cc.id = pl.id AND pl.pos = 0)
   JOIN places_common pc ON (pl.item = pc.refname)
   JOIN hierarchy hpc ON (pc.id = hpc.id AND hpc.primarytype = 'PlaceitemTenant15')
   JOIN utils.placename_hierarchy pn ON (hpc.name = pn.placecsid)


### PR DESCRIPTION
Changing data source field from collectionobjects_common.numberofobjects to objectcountgroup.objectcount.

Keeping "numberofobjects" field name in:
utils.object_place_temp
utils.object_place_view
utils.object_place_location

Will need to run as nuxeo user:
object_location/CreateObjectPlaceLocationTable.sql nuxeo
object_location/CreateObjectPlaceTable.sql nuxeo
object_location/CreateObjectPlaceView.sql nuxeo

Then run sql command to refresh data (or wait for nightly pahma_refresh.sh job.
select utils.refreshobjectplacelocationtable();